### PR TITLE
fixes #6: update of dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,13 +22,13 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.8.2</version>
+			<version>4.12</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.cassandraunit</groupId>
 			<artifactId>cassandra-unit-spring</artifactId>
-			<version>2.0.2.1-SNAPSHOT</version>
+			<version>2.1.3.1</version>
 			<scope>test</scope>
 		</dependency>
         <!--<dependency>-->


### PR DESCRIPTION
Update of dependencies:
- **junit**: `4.8.2` -> `4.12`
- **cassandra-unit-spring**: `2.0.2.1-SNAPHOT` (_not existing_) -> `2.1.3.1`
