### PR TITLE
FSWriteError when tests are in a submodule of a multimodule maven project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
                 <version>2.19.1</version>
                 <configuration>
                     <workingDirectory>${project.basedir}</workingDirectory>
-                    <forkMode>once</forkMode>
+                    <forkMode>always</forkMode>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -101,4 +101,19 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.19.1</version>
+                <configuration>
+                    <workingDirectory>${project.basedir}</workingDirectory>
+                    <forkMode>once</forkMode>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>


### PR DESCRIPTION
When tests are located into a submodule of a multimodule maven project, both CassandraUnit and Cassandra (I'm using 2.2.6) fail to delete files in `tmpDir`.
Frankly, I don't understand why: it looks like `file.toPath()` is fooled by a relative folder in Cassandra's `FileUtiles.deleteWithConfirm`.
Anyway, running tests forcing working directory to be module's one and forking the jvm solves the issue
This should also be part of the documentation
